### PR TITLE
docs: remove useless pkgdown navbar config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,27 +1,4 @@
-navbar:
-  structure:
-    left:
-    - home
-    - intro
-    - reference
-    - news
-    right: github
-  components:
-    home:
-      icon: fa-home fa-lg
-      href: index.html
-    reference:
-      text: Reference
-      href: reference/index.html
-    intro:
-      text: Get started
-      href: articles/phylotaR.html
-    news:
-      text: Changelog
-      href: news/index.html
-    github:
-      icon: fa-github fa-lg
-      href: https://github.com/ropensci/phylotaR
+
 reference:
 - title: Running
   desc:  Functions for starting/stopping the phylotaR pipeline.


### PR DESCRIPTION
Your config corresponded to the default https://pkgdown.r-lib.org/articles/customise.html#navbar-heading minus search so this PR will add the search bar